### PR TITLE
Use bioc docker devel instead of bioc2020

### DIFF
--- a/.github/workflows/basic_checks.yaml
+++ b/.github/workflows/basic_checks.yaml
@@ -2,7 +2,7 @@ on: [push]
 jobs:
   job1:
     runs-on: ubuntu-latest
-    container: bioconductor/bioconductor_docker:bioc2020
+    container: bioconductor/bioconductor_docker:devel
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
bioc2020 was a frozen devel image for the July workshops so prob better to go back to using devel